### PR TITLE
Fix: PPOPolicy load_from_pretrained arguments

### DIFF
--- a/convlab/policy/ppo/multiwoz/ppo_policy.py
+++ b/convlab/policy/ppo/multiwoz/ppo_policy.py
@@ -9,7 +9,5 @@ class PPOPolicy(PPO):
                         model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/ppo_policy_multiwoz.zip"
                         ):
         super().__init__(is_train=is_train, dataset=dataset)
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
-            cfg = json.load(f)
-        self.load_from_pretrained(archive_file, model_file, cfg['load'])
+        self.load_from_pretrained(model_file)
         


### PR DESCRIPTION
**Description:**

MultiWOZ's PPOPolicy load_from_pretrained arguments remain the same as in previous versions.

https://github.com/ConvLab/ConvLab-3/blob/c490c21489cab244e1eeb7f1b859a1ea66c3f76e/convlab/policy/ppo/multiwoz/ppo_policy.py#L14

Here we have taken three variables `archive_file`, `model_file` and `cfg['load']`, but they are from ConvLab2, the argument in ConvLab3 is only `model_path`.

https://github.com/ConvLab/ConvLab-3/blob/c490c21489cab244e1eeb7f1b859a1ea66c3f76e/convlab/policy/ppo/ppo.py#L267

Run a simple program as a test that only read PPOPolicy.

```python
from convlab.policy.ppo.multiwoz import PPOPolicy
sys_policy = PPOPolicy()
```

The current code would cause a TypeError.

```bash
Load actions from data..
Dimension of system actions: 208
Dimension of user actions: 79
State dimension: 361
Traceback (most recent call last):
  File "tmp.py", line 3, in <module>
    sys_policy = PPOPolicy()
  File "{My Current Directory}/ConvLab-3/convlab/policy/ppo/multiwoz/ppo_policy.py", line 14, in __init__
    self.load_from_pretrained(archive_file, model_file, cfg['load'])
TypeError: load_from_pretrained() takes from 1 to 2 positional arguments but 4 were given
```

~**Reference Issues:** #XX (XX is the issue number you work on)~
