### PR TITLE
add LLM supports for User Simulator, NLU, DST, NLG. The prompt can be further improved to enhance the controllability of LLM

### DIFF
--- a/convlab/base_models/llm/__init__.py
+++ b/convlab/base_models/llm/__init__.py
@@ -1,0 +1,2 @@
+from convlab.base_models.llm.base import LLM
+from convlab.base_models.llm.models import LLM_US, LLM_RG, LLM_DST, LLM_NLU, LLM_NLG

--- a/convlab/base_models/llm/base.py
+++ b/convlab/base_models/llm/base.py
@@ -189,8 +189,8 @@ class LLaMa2(HFModels):
 
 if __name__ == '__main__':
     # model = LLM('openai', 'gpt-3.5-turbo')
-    # model = LLM('huggingface', '/data/zhuqi/pre-trained-models/Llama-2-7b-chat-hf')
-    model = LLM('huggingface', '/data/zhuqi/pre-trained-models/chatglm2-6b')
+    # model = LLM('huggingface', 'Llama-2-7b-chat-hf')
+    model = LLM('huggingface', 'chatglm2-6b')
     print(model.__dict__)
     print(model.chat("Help me to find a Chinese restaurant in Beijing."))
     print(model.chat("Great"))

--- a/convlab/base_models/llm/base.py
+++ b/convlab/base_models/llm/base.py
@@ -1,0 +1,200 @@
+"""Wrapper for LLMs' API. Need transformers>=4.31.0 to use Llama-2."""
+import os
+import openai
+import torch
+from copy import deepcopy
+from transformers import pipeline, AutoTokenizer, AutoModel
+
+class LLM:
+    def __init__(self, api_type, model_name_or_path, system_instruction=None, generation_kwargs=None):
+        """Initialize the LLM wrapper
+        api_type: str, should be in API_TYPES
+        model_name_or_path: str, the model's id, name, or local path
+        system_instruction: str, the system_instruction prompt
+        generation_kwargs: dict, kwargs for the generation function
+        """
+        if api_type == 'openai':
+            self.model = OpenAI_API(model_name_or_path)
+            
+        elif api_type == 'huggingface':
+            if 'Llama-2' in model_name_or_path:
+                self.model = LLaMa2(model_name_or_path)
+            elif 'chatglm2' in model_name_or_path:
+                self.model = ChatGLM2(model_name_or_path)
+            else:
+                self.model = HFModels(model_name_or_path)
+        else:
+            raise NotImplementedError
+        
+        self.system_instruction = self.model.DEFAULT_SYSTEM_INSTRUCTION if system_instruction is None else system_instruction
+        self.messages = [{"role": "system", "content": self.system_instruction}]
+        self.generation_kwargs = {} if generation_kwargs is None else generation_kwargs
+            
+    def set_system_instruction(self, system_instruction):
+        """Set the system instruction"""
+        self.system_instruction = system_instruction
+        self.messages[0] = {"role": "system", "content": self.system_instruction}
+        
+    def chat(self, message, **kwargs):
+        """Chat with the LLM"""
+        self.messages.append({"role": "user", "content": message})
+        messages = deepcopy(self.messages)
+        assert len(messages) % 2 == 0
+        assert all([m["role"] == "user" for m in messages[1::2]]) and all([m["role"] == "assistant" for m in messages[2::2]])
+        response = self.model.chat(messages, **{**self.generation_kwargs, **kwargs})
+        self.messages.append({"role": "assistant", "content": response})
+        return response
+    
+    def clear_chat_history(self):
+        """Clear the chat history"""
+        self.messages = [{"role": "system", "content": self.system_instruction}]
+    
+    def generate(self, prompt, **kwargs):
+        """Generate a response given a prompt"""
+        response = self.model.generate(self.system_instruction, prompt, **{**self.generation_kwargs, **kwargs})
+        return response
+
+class BaseLLM:
+    DEFAULT_SYSTEM_INSTRUCTION = ''
+
+    def __init__(self, model_name_or_path):
+        """Initialize the LLM wrapper"""
+        raise NotImplementedError
+
+    def chat(self, messages, **kwargs):
+        """Chat interface, need to prepare the messages as the format of [OpenAI API](https://platform.openai.com/docs/api-reference/chat/create)"""
+        raise NotImplementedError
+    
+    def generate(self, system_instruction, prompt, **kwargs):
+        """Generate interface"""
+        raise NotImplementedError
+    
+class OpenAI_API(BaseLLM):
+    DEFAULT_SYSTEM_INSTRUCTION = "You are a helpful assistant."
+
+    def __init__(self, model_name_or_path) -> None:
+        # make sure you set the OPENAI_API_KEY environment variable by ``export OPENAI_API_KEY=YOUR_API_KEY`` in command line
+        # or you can set through ``os.environ['OPENAI_API_KEY'] = YOUR_API_KEY`` in the code
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        if openai.api_key is None:
+            raise ValueError('OPENAI_API_KEY is not set')
+        self.model_name_or_path = model_name_or_path
+    
+    def chat(self, messages, **kwargs) -> str:
+        completion = openai.ChatCompletion.create(
+            model=self.model_name_or_path,
+            messages=messages,
+            **kwargs
+        )
+        return completion.choices[0].message['content']
+    
+    def generate(self, system_instruction, prompt, **kwargs) -> str:
+        completion = openai.ChatCompletion.create(
+            model=self.model_name_or_path,
+            messages=[
+                {"role": "system", "content": system_instruction},
+                {"role": "user", "content": prompt}
+            ],
+            **kwargs
+        )
+        return completion.choices[0].message['content']
+
+class ChatGLM2(BaseLLM):
+    DEFAULT_SYSTEM_INSTRUCTION = "You are a helpful assistant."
+
+    def __init__(self, model_name_or_path):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=True)
+        self.model = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=True).half().cuda()
+        self.model = self.model.eval()
+    
+    def chat(self, messages, **kwargs):
+        messages = [{"role": messages[1]["role"], "content": messages[0]["content"] + "\n\n" + messages[1]["content"]}] + messages[2:]
+        history = [(query['content'], response['content']) for query, response in zip(messages[::2], messages[1::2])]
+        response, history = self.model.chat(self.tokenizer, messages[-1]['content'], history=history, **kwargs)
+        print(history)
+        return response
+    
+    def generate(self, system_instruction, prompt, **kwargs):
+        response, history = self.model.chat(self.tokenizer, system_instruction+"\n\n"+prompt, history=[], **kwargs)
+        print(history)
+        return response
+
+class HFModels(BaseLLM):
+    DEFAULT_GENERATION_KWARGS = {
+        "do_sample": True,
+        "max_new_tokens": 256,
+    } # aligned with OpenAI API
+    # See https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.GenerationConfig for more parameters
+    DEFAULT_SYSTEM_INSTRUCTION = "You are a helpful assistant."
+
+    def __init__(self, model_name_or_path) -> None:
+        # login through command line "huggingface-cli login" to assess some models such as LLaMa-2
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        """Need transformers>=4.31.0 to use Llama-2."""
+        self.pipeline = pipeline(
+            "text-generation",
+            model=model_name_or_path,
+            tokenizer=self.tokenizer,
+            torch_dtype=torch.float16,
+            device_map="auto",
+        )
+
+    def create_chat_prompt_and_eos_token(self, messages):
+        prompt = messages[0]['content'] + "\n\n"
+        for m in messages[1:]:
+            prompt += f"{m['role']}: {m['content']}\n"
+        prompt += f"assistant: "
+        return prompt, '\n'
+
+    def chat(self, messages, **kwargs):
+        prompt, eos_token = self.create_chat_prompt_and_eos_token(messages)
+        sequences = self.pipeline(
+            prompt,
+            prefix=None, # do not add additional special tokens
+            eos_token_id=self.tokenizer.convert_tokens_to_ids(eos_token),
+            **{**self.DEFAULT_GENERATION_KWARGS, **kwargs}
+        )
+        response = sequences[0]['generated_text'][len(prompt):].strip()
+        return response
+        
+    def generate(self, system_instruction, prompt, **kwargs):
+        prompt = (system_instruction+"\n\n"+prompt).strip()
+        sequences = self.pipeline(
+            prompt,
+            eos_token_id=self.tokenizer.eos_token_id,
+            **{**self.DEFAULT_GENERATION_KWARGS, **kwargs}
+        )
+        response = sequences[0]['generated_text'][len(prompt):].strip()
+        return response
+
+class LLaMa2(HFModels):
+    DEFAULT_SYSTEM_INSTRUCTION = """You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information."""
+
+    def create_chat_prompt_and_eos_token(self, messages):
+        """https://github.com/facebookresearch/llama/blob/6c7fe276574e78057f917549435a2554000a876d/llama/generation.py#L213"""
+        B_INST, E_INST = "[INST]", "[/INST]"
+        B_SYS, E_SYS = "<<SYS>>\n", "\n<</SYS>>\n\n"
+        BOS, EOS = "<s>", "</s>"
+
+        messages = [{"role": messages[1]["role"], "content": B_SYS + messages[0]["content"] + E_SYS + messages[1]["content"]}] + messages[2:]
+
+        messages_list = [
+            f"{BOS}{B_INST} {(prompt['content']).strip()} {E_INST} {(answer['content']).strip()} {EOS}"
+            for prompt, answer in zip(messages[::2], messages[1::2])
+        ]
+        messages_list.append(f"{BOS}{B_INST} {(messages[-1]['content']).strip()} {E_INST}")
+
+        return "".join(messages_list), self.tokenizer.eos_token
+    
+
+if __name__ == '__main__':
+    # model = LLM('openai', 'gpt-3.5-turbo')
+    # model = LLM('huggingface', '/data/zhuqi/pre-trained-models/Llama-2-7b-chat-hf')
+    model = LLM('huggingface', '/data/zhuqi/pre-trained-models/chatglm2-6b')
+    print(model.__dict__)
+    print(model.chat("Help me to find a Chinese restaurant in Beijing."))
+    print(model.chat("Great"))
+    print(model.messages)
+    model.set_system_instruction("Let's play a game. I'll start my sentence with 'fortunately' and you should go on but start the sentence with 'unfortunately'")
+    print(model.generate('fortunately, you are an AI.'))
+    

--- a/convlab/base_models/llm/models.py
+++ b/convlab/base_models/llm/models.py
@@ -544,11 +544,14 @@ def test_LLM_NLG():
     ]
     dataset = load_dataset('multiwoz21')
     example_dialogs = dataset['train'][:3]
-    nlg = LLM_NLG('multiwoz21', 'huggingface', '/data/zhuqi/pre-trained-models/Llama-2-7b-chat-hf', 'system', example_dialogs)
+    nlg = LLM_NLG('multiwoz21', 'huggingface', 'Llama-2-7b-chat-hf', 'system', example_dialogs)
     for da, context in zip(das, contexts):
         print(da)
         print(nlg.generate(da, context))
         print()
 
 if __name__ == '__main__':
+    test_LLM_US_RG()
+    test_LLM_DST()
+    test_LLM_NLU()
     test_LLM_NLG()

--- a/convlab/base_models/llm/models.py
+++ b/convlab/base_models/llm/models.py
@@ -1,0 +1,554 @@
+import json
+from copy import deepcopy
+from convlab.base_models.llm.base import LLM
+from convlab.dialog_agent import Agent
+from convlab.nlu import NLU
+from convlab.dst import DST
+from convlab.nlg import NLG
+from convlab.util.unified_datasets_util import load_dataset, load_ontology
+
+class LLM_US(Agent):
+    DEFAULT_SYSTEM_INSTRUCTION = " ".join([
+        "Imagine you are a user chatting with a helpful assistant to achieve a goal.",
+        "You should chat according to the given goal faithfully and naturally.",
+        "You should not generate all the information in the goal at once.",
+        "You should generate short, precise, and informative response (less than 50 tokens), corresponding to only one or two items in the goal.",
+        "You should not generate information not presented in the goal.",
+        "If and only if you achieve your goal, express your thanks and generate **\"[END]\"** token.",
+        "If you think the assistant can not help you or the conversation falls into a infinite loop, generate **\"[STOP]\"** token."
+    ])
+    default_reward_func = lambda goal, dialog, completed: 40 if completed else -20
+
+    def __init__(self, api_type, model_name_or_path, system_instruction=DEFAULT_SYSTEM_INSTRUCTION, reward_func=default_reward_func, generation_kwargs=None):
+        self.system_instruction = system_instruction
+        self.model = LLM(api_type, model_name_or_path, system_instruction, generation_kwargs)
+        self.reward_func = reward_func
+    
+    def reset(self):
+        self.model.clear_chat_history()
+        self.is_terminated = False
+        self.reward = None
+
+    def init_session(self, goal, example_dialog:str=None):
+        self.goal = goal
+        goal_description = '.\n'.join(['* '+item for item in self.goal['description'].split('. ')])
+        system_instruction = f"Goal:\n{goal_description}"
+        system_instruction += f"\n\n{self.system_instruction}"
+        if example_dialog is not None:
+            system_instruction += f"\n\nExample dialog:\n{example_dialog}"
+        self.model.set_system_instruction(system_instruction)
+        # print(self.model.system_instruction)
+        self.reset()
+
+    def is_terminated(self):
+        return self.is_terminated
+    
+    def response(self, message):
+        if self.is_terminated:
+            return None
+        response = self.model.chat(message)
+        if "[END]" in response:
+            self.reward = self.reward_func(self.goal, self.model.messages, True)
+            self.is_terminated = True
+        elif "[STOP]" in response:
+            self.reward = self.reward_func(self.goal, self.model.messages, False)
+            self.is_terminated = True
+        return response
+
+    def get_reward(self):
+        return self.reward
+
+
+class LLM_RG(Agent):
+    DEFAULT_SYSTEM_INSTRUCTION = " ".join([
+        "Imagine you are a helpful assistant that can help the user to complete their task.",
+        "You should generate short, precise, and informative response (less than 50 tokens), providing only necessary information.",
+        # "You should not generate emoji or special symbols.",
+    ])
+    def __init__(self, api_type, model_name_or_path, system_instruction=DEFAULT_SYSTEM_INSTRUCTION, generation_kwargs=None):
+        self.system_instruction = system_instruction
+        self.model = LLM(api_type, model_name_or_path, system_instruction, generation_kwargs)
+    
+    def reset(self):
+        self.model.clear_chat_history()
+
+    def init_session(self, example_dialog:str=None):
+        system_instruction = f"{self.system_instruction}"
+        if example_dialog is not None:
+            system_instruction += f"\n\nExample dialog:\n{example_dialog}"
+        self.model.set_system_instruction(system_instruction)
+        # print(self.model.system_instruction)
+        self.reset()
+    
+    def response(self, message):
+        response = self.model.chat(message)
+        return response
+
+
+class LLM_DST(DST):
+    def __init__(self, dataset_name, api_type, model_name_or_path, generation_kwargs=None):
+        self.ontology = load_ontology(dataset_name)
+        self.system_instruction = self.format_system_instruction(self.ontology)
+        # print(self.system_instruction)
+        self.model = LLM(api_type, model_name_or_path, self.system_instruction, generation_kwargs)
+        self.state_update = []
+
+    def format_system_instruction(self, ontology):
+        # From paper "ChatGPT for Zero-shot Dialogue State Tracking: A Solution or an Opportunity?"
+        # http://arxiv.org/abs/2306.01386
+        state = ontology['state']
+        slot_descriptions = deepcopy(ontology['state'])
+        categorical_slot_values = deepcopy(ontology['state'])
+        
+        for domain in state:
+            for slot in state[domain]:
+                slot_descriptions[domain][slot] = ontology['domains'][domain]['slots'][slot]['description']
+                if ontology['domains'][domain]['slots'][slot]['is_categorical']:
+                    categorical_slot_values[domain][slot] = ontology['domains'][domain]['slots'][slot]['possible_values']
+                else:
+                    categorical_slot_values[domain].pop(slot)
+            if categorical_slot_values[domain] == {}:
+                categorical_slot_values.pop(domain)
+        
+        system_instruction = "\n\n".join([
+            """Consider the following list of concepts , called "slots" provided to you as a json dictionary.""",
+            "\"slots\": "+json.dumps(slot_descriptions, indent=4),
+            """Some "slots" can only take a value from predefined list:""",
+            "\"categorical\": "+json.dumps(categorical_slot_values, indent=4),
+            """Now consider the following dialogue between two parties called the "system" and "user". Can you tell me which of the "slots" were updated by the "user" in its latest response to the "system"?""",
+            """Present the updates in **JSON** format, start with <JSON> token and end with </JSON> token. Example: "<JSON>{"hotel": {"name": "abc"}}</JSON>". **Do not forget the "}" token**. If no "slots" were updated, return an empty JSON dictionary. If a user does not seem to care about a discussed "slot" fill it with "dontcare"."""
+        ])
+                
+        return system_instruction
+    
+    def format_turn_prompt(self, user_utterance, system_utterance):
+        return '"system": "{}"\n"user": "{}"'.format(system_utterance, user_utterance)
+
+    def normalize_response_to_state_update(self, response):
+        start_token, end_token = "<JSON>", "</JSON>"
+        start_idx = response.find(start_token)
+        end_idx = response.find(end_token)
+        if start_idx == -1 or end_idx == -1:
+            return {}
+        response = response[start_idx+len(start_token):end_idx].strip()
+        if response == "":
+            return {}
+        try:
+            state_update = json.loads(response)
+        except json.decoder.JSONDecodeError:
+            # print('JSONDecodeError')
+            # print('*'*30)
+            # print([response])
+            # print('*'*30)
+            return {}
+        return state_update
+
+    def update(self, user_action=None):
+        assert user_action == None
+        context = self.state['history']
+        assert len(context) > 0
+        if type(context[0]) is list:
+            assert len(context[0]) > 1
+            context = [item[1] for item in context]
+        if len(context) % 2 == 0:
+            # system/user/system/user
+            assert context[0] == ''
+        else:
+            # first turn: empty system utterance
+            context.insert(0, '')
+        
+        assert len(context)//2 >= len(self.state_update) + 1
+        for i in range(len(self.state_update), len(context)//2):
+            system_utterance = context[2*i]
+            user_utterance = context[2*i+1]
+            turn_prompt = self.format_turn_prompt(user_utterance, system_utterance)
+            response = self.model.chat(turn_prompt)
+            state_update = self.normalize_response_to_state_update(response)
+            # print(turn_prompt)
+            # print(response)
+            # print(state_update)
+            # print('---'*50)
+            self.state_update.append(state_update)
+
+        self.state['belief_state'] = deepcopy(self.ontology['state'])
+        for state_update in self.state_update:
+            for domain in state_update:
+                if domain not in self.state['belief_state']:
+                    continue
+                for slot in state_update[domain]:
+                    if slot not in self.state['belief_state'][domain]:
+                        continue
+                    self.state['belief_state'][domain][slot] = state_update[domain][slot]
+        return self.state
+    
+    def init_session(self):
+        self.state = dict()
+        self.state['belief_state'] = deepcopy(self.ontology['state'])
+        self.state['booked'] = dict()
+        self.state['history'] = []
+        self.state['system_action'] = []
+        self.state['user_action'] = []
+        self.state['terminated'] = False
+        self.state_update = []
+        self.model.clear_chat_history()
+
+
+class LLM_NLU(NLU):
+    def __init__(self, dataset_name, api_type, model_name_or_path, speaker, example_dialogs, generation_kwargs=None):
+        assert speaker in ['user', 'system']
+        self.speaker = speaker
+        self.opponent = 'system' if speaker == 'user' else 'user'
+        self.ontology = load_ontology(dataset_name)
+        self.system_instruction = self.format_system_instruction(self.ontology, example_dialogs)
+        print(self.system_instruction)
+        self.model = LLM(api_type, model_name_or_path, self.system_instruction, generation_kwargs)
+
+    def format_system_instruction(self, ontology, example_dialogs):
+        intents = {intent: ontology['intents'][intent]['description'] for intent in ontology['intents']}
+        # domains = {domain: '' for domain in ontology['domains']}
+        slots = {domain: {
+                    slot: ontology['domains'][domain]['slots'][slot]['description'] 
+                    for slot in ontology['domains'][domain]['slots']
+                } for domain in ontology['domains']}
+        
+        # categorical_slot_values = {domain: {
+        #                             slot: ontology['domains'][domain]['slots'][slot]['possible_values']
+        #                             for slot in ontology['domains'][domain]['slots'] if ontology['domains'][domain]['slots'][slot]['is_categorical']
+        #                         } for domain in ontology['domains']}
+        
+        example = ''
+        for example_dialog in example_dialogs:
+            for i, turn in enumerate(example_dialog['turns']):
+                if turn['speaker'] == self.speaker:
+                    if i > 0:
+                        example += example_dialog['turns'][i-1]['speaker']+': '+example_dialog['turns'][i-1]['utterance']+'\n'
+                    example += turn['speaker']+': '+turn['utterance']+'\n'
+                    das = []
+                    for da_type in turn['dialogue_acts']:
+                        for da in turn['dialogue_acts'][da_type]:
+                            intent, domain, slot, value = da.get('intent'), da.get('domain'), da.get('slot', ''), da.get('value', '')
+                            das.append((intent, domain, slot, value))
+                    example += '<DA>'+json.dumps(das)+'</DA>'+'\n\n'
+        
+        system_instruction = "\n\n".join([
+            """You are an excellent dialogue acts parser. Dialogue acts are used to represent the intention of the speaker. Dialogue acts are a list of tuples, each tuple is in the form of (intent, domain, slot, value). The "intent", "domain", "slot" are defines as follows:""",
+            '"intents": '+json.dumps(intents, indent=4),
+            # '"domains": '+json.dumps(domains, indent=4),
+            '"domain2slots": '+json.dumps(slots, indent=4),
+            """Here are example dialogue acts:""",
+            example,
+            """Now consider the following dialogue. Please generate the dialogue acts of the last utterance of {}. Start with <DA> token and end with </DA> token. Example: "<DA>[["inform", "hotel", "name": "abc"]]</DA>". Do not generate intents, domains, slots that are not defined above.""".format(self.speaker)
+        ])
+                
+        return system_instruction
+
+    
+    def predict(self, utterance, context=list()):
+        prompt = ""
+        for i, turn in enumerate(context[::-1][:1]):
+            # only the last utterance of the opponent is used
+            if i % 2 == 0:
+                prompt = self.opponent+': '+turn+'\n' + prompt
+            else:
+                prompt = self.speaker+': '+turn+'\n' + prompt
+        prompt += self.speaker+': '+utterance+'\n'
+        # print('='*50)
+        # print('prompt')
+        # print(prompt)
+        response = self.model.chat(prompt)
+        self.model.clear_chat_history()
+        # print('response')
+        # print(response)
+        # print('='*50)
+        dialogue_acts = self.normalize_response_to_dialogue_acts(response)
+        return dialogue_acts
+    
+    def normalize_response_to_dialogue_acts(self, response):
+        start_token, end_token = "<DA>", "</DA>"
+        start_idx = response.find(start_token)
+        end_idx = response.find(end_token)
+        if start_idx == -1 or end_idx == -1:
+            return {}
+        response = response[start_idx+len(start_token):end_idx].strip()
+        if response == "":
+            return {}
+        try:
+            dialogue_acts = json.loads(response)
+        except json.decoder.JSONDecodeError:
+            # print('JSONDecodeError')
+            # print('*'*30)
+            # print([response])
+            # print('*'*30)
+            return {}
+        return dialogue_acts
+    
+
+class LLM_NLG(NLG):
+    def __init__(self, dataset_name, api_type, model_name_or_path, speaker, example_dialogs, generation_kwargs=None):
+        assert speaker in ['user', 'system']
+        self.speaker = speaker
+        self.opponent = 'system' if speaker == 'user' else 'user'
+        self.ontology = load_ontology(dataset_name)
+        self.system_instruction = self.format_system_instruction(self.ontology, example_dialogs)
+        # print(self.system_instruction)
+        self.model = LLM(api_type, model_name_or_path, self.system_instruction, generation_kwargs)
+
+    def format_system_instruction(self, ontology, example_dialogs):
+        intents = {intent: ontology['intents'][intent]['description'] for intent in ontology['intents']}
+        # domains = {domain: '' for domain in ontology['domains']}
+        slots = {domain: {
+                    slot: ontology['domains'][domain]['slots'][slot]['description'] 
+                    for slot in ontology['domains'][domain]['slots']
+                } for domain in ontology['domains']}
+        
+        # categorical_slot_values = {domain: {
+        #                             slot: ontology['domains'][domain]['slots'][slot]['possible_values']
+        #                             for slot in ontology['domains'][domain]['slots'] if ontology['domains'][domain]['slots'][slot]['is_categorical']
+        #                         } for domain in ontology['domains']}
+        
+        example = ''
+        for example_dialog in example_dialogs:
+            for i, turn in enumerate(example_dialog['turns']):
+                if turn['speaker'] == self.speaker:
+                    if i > 0:
+                        example += example_dialog['turns'][i-1]['speaker']+': '+example_dialog['turns'][i-1]['utterance']+'\n'
+                    das = []
+                    for da_type in turn['dialogue_acts']:
+                        for da in turn['dialogue_acts'][da_type]:
+                            intent, domain, slot, value = da.get('intent'), da.get('domain'), da.get('slot', ''), da.get('value', '')
+                            das.append((intent, domain, slot, value))
+                    example += '<DA>'+json.dumps(das)+'</DA>'+'\n'
+                    example += turn['speaker']+': '+'<UTT>'+turn['utterance']+'</UTT>'+'\n\n'
+        
+        system_instruction = "\n\n".join([
+            """You are an excellent writing machine. You can generate fluent and precise natural language according to the given dialogue acts. Dialogue acts are a list of tuples, each tuple is in the form of (intent, domain, slot, value). The "intent", "domain", "slot" are defines as follows:""",
+            '"intents": '+json.dumps(intents, indent=4),
+            '"domain2slots": '+json.dumps(slots, indent=4),
+            """Here are some examples:""",
+            example,
+            """Now consider the following dialogue acts. Please generate an utterance of {} that can express the given dialogue acts precisely. Start with <UTT> token and end with </UTT> token. Example: "<UTT>utterance</UTT>". Do not generate unrelated intents, domains, and slots that are not in the given dialogue acts.""".format(self.speaker)
+        ])
+                
+        return system_instruction
+    
+    def format_dialogue_acts(self, dialogue_acts):
+        das = []
+                
+        if isinstance(dialogue_acts, dict):
+            # da in unified format
+            for da_type in dialogue_acts:
+                for da in dialogue_acts[da_type]:
+                    intent, domain, slot, value = da['intent'], da['domain'], da['slot'], da.get('value', '')
+                    das.append((intent, domain, slot, value))
+        elif isinstance(dialogue_acts[0], dict):
+            # da without da type
+            for da in dialogue_acts:
+                intent, domain, slot, value = da['intent'], da['domain'], da['slot'], da.get('value', '')
+                das.append((intent, domain, slot, value))
+        elif isinstance(dialogue_acts[0], list):
+            # da is a list of list (convlab-2 format)
+            das = dialogue_acts
+        else:
+            raise ValueError(f"invalid dialog acts format {dialogue_acts}")
+        return das
+
+    def generate(self, dialogue_acts, context=list()):
+        das = self.format_dialogue_acts(dialogue_acts)
+        prompt = ""
+        # # relevant concepts
+        # prompt += "Relevant concepts:\n"
+        # intents = set([da[0] for da in das])
+        # prompt += '"intents": '+json.dumps({intent: self.ontology['intents'][intent]['description'] for intent in self.ontology['intents'] if intent in intents}, indent=4)+'\n\n'
+        # slots = {}
+        # for da in das:
+        #     domain, slot = da[1], da[2]
+        #     if domain not in slots:
+        #         slots[domain] = {}
+        #     if slot not in slots[domain] and slot in self.ontology['domains'][domain]['slots']:
+        #         slots[domain][slot] = self.ontology['domains'][domain]['slots'][slot]['description']
+        # prompt += '"domain2slots": '+json.dumps(slots, indent=4)+'\n\n'
+
+        prompt += self.opponent+': '+context[-1]+'\n'
+        prompt += '<DA>'+json.dumps(das)+'</DA>'+'\n\n'
+        # print('='*50)
+        # print('prompt')
+        # print(prompt)
+        response = self.model.chat(prompt)
+        self.model.clear_chat_history()
+        # print('response')
+        # print(response)
+        # print('='*100)
+        response = self.normalize_response(response)
+        return response
+    
+    def normalize_response(self, response):
+        start_token, end_token = "<UTT>", "</UTT>"
+        start_idx = response.find(start_token)
+        end_idx = response.find(end_token)
+        if start_idx == -1 or end_idx == -1:
+            return {}
+        response = response[start_idx+len(start_token):end_idx].strip()
+        return response
+
+
+def test_LLM_US_RG():
+    dataset = load_dataset('multiwoz21')
+    goal = dataset['validation'][0]['goal']
+    example_dialog = '\n'.join([f"{turn['speaker'] if turn['speaker'] == 'user' else 'assistant'}: {turn['utterance']}" for turn in dataset['train'][0]['turns']])
+    user_model = LLM_US('huggingface', 'Llama-2-7b-chat-hf')
+    user_model.init_session(goal)
+    system_model = LLM_RG('huggingface', 'Llama-2-7b-chat-hf')
+    system_model.init_session()
+    system_msg = "Hello, I am a helpful assistant. How may I help you?"
+    print()
+    print(system_msg)
+    max_turn = 20
+    while not user_model.is_terminated and max_turn > 0:
+        user_msg = user_model.response(system_msg)
+        system_msg = system_model.response(user_msg)
+        print()
+        print(user_msg)
+        print(user_model.is_terminated)
+        print()
+        print(system_msg)
+        max_turn -= 1
+
+def test_LLM_DST():
+    contexts = [
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton."],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15."],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15.",
+        "Booking completed! your taxi will be blue honda Contact number is 07218068540",
+        "Thank you for all the help! I appreciate it."],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15.",
+        "Booking completed! your taxi will be blue honda Contact number is 07218068540",
+        "Thank you for all the help! I appreciate it.",
+        "You are welcome.  Is there anything else I can help you with today?",
+        "No, I am all set.  Have a nice day.  Bye."],
+    ]
+    dst = LLM_DST('multiwoz21', 'huggingface', 'Llama-2-7b-chat-hf')
+    dst.init_session()
+    for context in contexts:
+        dst.state['history'] = context
+        # dst.update()
+        print(dst.update())
+        print('='*100)
+
+def test_LLM_NLU():
+    texts = [
+        "I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "I want to leave after 17:15.",
+        "Thank you for all the help! I appreciate it.",
+        "Please find a restaurant called Nusha.",
+        "I am not sure of the type of food but could you please check again and see if you can find it? Thank you.",
+        "It's not a restaurant, it's an attraction. Nusha."
+    ]
+    contexts = [
+        [],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?"],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15.",
+        "Booking completed! your taxi will be blue honda Contact number is 07218068540"],
+        [],
+        ["Please find a restaurant called Nusha.",
+        "I don't seem to be finding anything called Nusha.  What type of food does the restaurant serve?"],
+        ["Please find a restaurant called Nusha.",
+        "I don't seem to be finding anything called Nusha.  What type of food does the restaurant serve?",
+        "I am not sure of the type of food but could you please check again and see if you can find it? Thank you.",
+        "Could you double check that you've spelled the name correctly? The closest I can find is Nandos."]
+    ]
+    dataset = load_dataset('multiwoz21')
+    example_dialogs = dataset['train'][:3]
+    nlu = LLM_NLU('multiwoz21', 'huggingface', 'Llama-2-7b-chat-hf', 'user', example_dialogs)
+    for text, context in zip(texts, contexts):
+        # print(text)
+        print(nlu.predict(text, context))
+        print('-'*50)
+
+def test_LLM_NLG():
+    das = [
+        { # da in unified format
+        "categorical": [],
+        "non-categorical": [],
+        "binary": [
+            {
+            "intent": "request",
+            "domain": "taxi",
+            "slot": "leave at"
+            },
+            {
+            "intent": "request",
+            "domain": "taxi",
+            "slot": "arrive by"
+            }
+        ]
+        },
+        [ # da without da type
+            {
+            "intent": "inform",
+            "domain": "taxi",
+            "slot": "type",
+            "value": "blue honda",
+            "start": 38,
+            "end": 48
+            },
+            {
+            "intent": "inform",
+            "domain": "taxi",
+            "slot": "phone",
+            "value": "07218068540",
+            "start": 67,
+            "end": 78
+            }
+        ],
+        [ # da is a list of list (convlab-2 format)
+            ["reqmore", "general", "", ""]
+        ],
+        {
+        "categorical": [],
+        "non-categorical": [],
+        "binary": [
+            {
+            "intent": "bye",
+            "domain": "general",
+            "slot": ""
+            }
+        ]
+        }
+    ]
+    contexts = [
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton."],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15."],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15.",
+        "Booking completed! your taxi will be blue honda Contact number is 07218068540",
+        "Thank you for all the help! I appreciate it."],
+        ["I would like a taxi from Saint John's college to Pizza Hut Fen Ditton.",
+        "What time do you want to leave and what time do you want to arrive by?",
+        "I want to leave after 17:15.",
+        "Booking completed! your taxi will be blue honda Contact number is 07218068540",
+        "Thank you for all the help! I appreciate it.",
+        "You are welcome.  Is there anything else I can help you with today?",
+        "No, I am all set.  Have a nice day.  Bye."],
+    ]
+    dataset = load_dataset('multiwoz21')
+    example_dialogs = dataset['train'][:3]
+    nlg = LLM_NLG('multiwoz21', 'huggingface', '/data/zhuqi/pre-trained-models/Llama-2-7b-chat-hf', 'system', example_dialogs)
+    for da, context in zip(das, contexts):
+        print(da)
+        print(nlg.generate(da, context))
+        print()
+
+if __name__ == '__main__':
+    test_LLM_NLG()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='convlab',
-    version='3.0.2a',
+    version='3.0.2b',
     packages=find_packages(),
     license='Apache',
     description='An Open-source Dialog System Toolkit',
@@ -55,7 +55,8 @@ setup(
         'fuzzywuzzy',
         'json_lines',
         'gtts',
-        'pydub'
+        'pydub',
+        'openai'
     ],
     extras_require={
         'develop': [


### PR DESCRIPTION
**Description:**
Add LLM-based user simulator, NLU, DST, NLG. Note that zero-shot or few-shot prompting could not encode domain knowledge entirely, so the LLM behavior may be unexpected (depending on the model).

Currently supported models: OpenAI APIs, LLaMA-2, ChatGLM2.

Usage:
```python
# base class, wrap OpenAI API, LLaMa-2, ChatGLM2, and models from hugging face hub
from convlab.base_models.llm import LLM

model = LLM('openai', 'gpt-3.5-turbo')
model = LLM('huggingface', 'Llama-2-7b-chat-hf')
model.chat(message)
model.generate(prompt)

# interface for each module
from convlab.base_models.llm import LLM_US, LLM_RG, LLM_DST, LLM_NLU, LLM_NLG
# see `ConvLab-3/convlab/base_models/llm/models.py` for example usage.
```
